### PR TITLE
stab_custo_v3-27: fix missing command in supervisor

### DIFF
--- a/etc/supervisor/app.conf.tpl
+++ b/etc/supervisor/app.conf.tpl
@@ -25,7 +25,11 @@ stderr_logfile_maxbytes = 0
 {{- if (eq (getenv "APP") "nuxt")}}
 [program:nuxt]
 directory=/srv/app/
-command= {{ getenv "NUXT_COMMAND" (getenv "NUXT_COMMAND" "npx nuxt-start") }}
+{{- if eq (getenv "ENVIRONMENT") "development"}}
+command=yarn watch
+{{- else }}
+command=npx nuxt-start
+{{- end }}
 autostart=true
 autorestart=true
 stderr_logfile = /dev/stderr


### PR DESCRIPTION
 - Correction de la commande supervisor de Nuxt en mode développement